### PR TITLE
03 react native svg ss

### DIFF
--- a/MentalHealthAppFrontEnd/package.json
+++ b/MentalHealthAppFrontEnd/package.json
@@ -55,7 +55,8 @@
     "react-native-vector-icons": "^10.2.0",
     "react-native-web": "~0.19.10",
     "react-slick": "^0.30.2",
-    "slick-carousel": "^1.8.1"
+    "slick-carousel": "^1.8.1",
+    "react-native-svg": "15.2.0"
   },
   "devDependencies": {
     "@babel/core": "^7.20.0",


### PR DESCRIPTION
The profile page in the android local dev build was crashing the app with error: `Invariant Violation: requireNtiveComponent: "RNSVGRect" was not found in the UIManager`. To correct this I installed react native svg in the front end.