### PR TITLE
04 expo linking ss

### DIFF
--- a/MentalHealthAppFrontEnd/android/app/src/main/AndroidManifest.xml
+++ b/MentalHealthAppFrontEnd/android/app/src/main/AndroidManifest.xml
@@ -26,6 +26,7 @@
         <category android:name="android.intent.category.DEFAULT"/>
         <category android:name="android.intent.category.BROWSABLE"/>
         <data android:scheme="com.csutton.mentalhealthapp"/>
+        <data android:scheme="mentalhealthappfrontend"/>
       </intent-filter>
     </activity>
     <activity android:name="com.facebook.react.devsupport.DevSettingsActivity" android:exported="false"/>

--- a/MentalHealthAppFrontEnd/app.json
+++ b/MentalHealthAppFrontEnd/app.json
@@ -2,6 +2,7 @@
   "expo": {
     "name": "mentalhealthappfrontend",
     "slug": "mentalhealthappfrontend",
+    "scheme": "mentalhealthappfrontend",
     "version": "1.0.0",
     "sdkVersion": "51.0.0",
     "platforms": [

--- a/MentalHealthAppFrontEnd/app/crisis/CrisisScreen.tsx
+++ b/MentalHealthAppFrontEnd/app/crisis/CrisisScreen.tsx
@@ -5,12 +5,12 @@ import {
   Text,
   StyleSheet,
   TouchableOpacity,
-  Linking,
   ScrollView,
   ActivityIndicator,
   Alert,
   Dimensions,
 } from "react-native";
+import * as Linking from 'expo-linking';
 import Icon from "react-native-vector-icons/MaterialIcons";
 import { getCrisisDocuments } from "../../api/crisis";
 import { crisisDocumentModel } from "@/models/crisisDocumentModel";

--- a/MentalHealthAppFrontEnd/app/home/HomeScreen.tsx
+++ b/MentalHealthAppFrontEnd/app/home/HomeScreen.tsx
@@ -6,8 +6,8 @@ import {
   StyleSheet,
   TouchableOpacity,
   ScrollView,
-  Linking,
 } from "react-native";
+import * as Linking from 'expo-linking';
 import Icon from "react-native-vector-icons/MaterialIcons";
 import { hasSubmittedDailyCheckin } from "@/api/checkin";
 import { getCurrentUser, signout } from "@/api/auth";

--- a/MentalHealthAppFrontEnd/app/profile/ProfileScreen.tsx
+++ b/MentalHealthAppFrontEnd/app/profile/ProfileScreen.tsx
@@ -8,8 +8,8 @@ import {
   ScrollView,
   Button,
   Dimensions,
-  Linking,
 } from "react-native";
+import * as Linking from 'expo-linking';
 import { LineChart } from "react-native-chart-kit";
 import * as ImagePicker from "expo-image-picker";
 import { useThemeContext } from "@/components/ThemeContext";

--- a/MentalHealthAppFrontEnd/package.json
+++ b/MentalHealthAppFrontEnd/package.json
@@ -55,7 +55,8 @@
     "react-native-vector-icons": "^10.2.0",
     "react-native-web": "~0.19.10",
     "react-slick": "^0.30.2",
-    "slick-carousel": "^1.8.1"
+    "slick-carousel": "^1.8.1",
+    "react-native-svg": "15.2.0"
   },
   "devDependencies": {
     "@babel/core": "^7.20.0",


### PR DESCRIPTION
Using expo linking vs react-native linking. This resolves the warning at app launch about Linking and android native modules. 